### PR TITLE
Fix missing Stripe secret key

### DIFF
--- a/lib/widget/app_constant.dart
+++ b/lib/widget/app_constant.dart
@@ -1,1 +1,5 @@
 const String publishableKey = 'pk_test_REPLACE_WITH_YOUR_KEY';
+
+/// Secret API key used when creating payment intents. Replace the value with
+/// your Stripe secret key before running the application.
+const String secretKey = 'sk_test_REPLACE_WITH_YOUR_SECRET_KEY';


### PR DESCRIPTION
## Summary
- add Stripe secret key constant for wallet payment

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a2183f7c832191c945d1108b35e1